### PR TITLE
Accelerate OVS traffic

### DIFF
--- a/qsdk5.0.2/0001-accelerate-ovs-traffic.patch
+++ b/qsdk5.0.2/0001-accelerate-ovs-traffic.patch
@@ -1,0 +1,228 @@
+The interfaces of ovs going through post routing would be LOCAL port rather than
+actual ingress/egress ports. We retrieve them by using ovs flow and use them to
+establish the correct hierarchy from which ECM module learn the connection.
+
+diff --git a/qsdk/qca/feeds/nss-host/qca-nss-ecm/patches/001-ecm_ovs_support.patch b/qsdk/qca/feeds/nss-host/qca-nss-ecm/patches/001-ecm_ovs_support.patch
+new file mode 100644
+index 000000000..c1f384673
+--- /dev/null
++++ b/qsdk/qca/feeds/nss-host/qca-nss-ecm/patches/001-ecm_ovs_support.patch
+@@ -0,0 +1,66 @@
++--- a/Makefile
+++++ b/Makefile
++@@ -148,6 +148,12 @@ endif
++ endif
++ 
++ # #############################################################################
+++# Define ECM_INTERFACE_OVS_ENABLE=y in order to enable support for OVS
+++# #############################################################################
+++ECM_INTERFACE_OVS_ENABLE=y
+++ccflags-$(ECM_INTERFACE_OVS_ENABLE) += -DECM_INTERFACE_OVS_ENABLE
+++
+++# #############################################################################
++ # Define ECM_INTERFACE_VLAN_ENABLE=y in order to enable support for VLAN
++ # #############################################################################
++ ECM_INTERFACE_VLAN_ENABLE=y
++--- a/ecm_interface.c
+++++ b/ecm_interface.c
++@@ -3265,6 +3265,8 @@ static struct net_device *ecm_interface_
++ 	return bridge;
++ }
++ 
+++extern int ovs_is_internal_dev(const struct net_device *netdev);
+++extern struct net_device *ovs_port_dev_get(struct net_device *dest_dev, char *mac, int ip_version, struct sk_buff *skb);
++ /*
++  * ecm_interface_heirarchy_construct()
++  *	Construct an interface heirarchy.
++@@ -3321,6 +3323,7 @@ int32_t ecm_interface_heirarchy_construc
++ 	struct net_device *bridge;
++ 	struct net_device *top_dev_vlan = NULL;
++ 	uint32_t serial = ecm_db_connection_serial_get(feci->ci);
+++	uint8_t ovs_internal_dev_cnt;
++ 
++ 	/*
++ 	 * Get a big endian of the IPv4 address we have been given as our starting point.
++@@ -3561,6 +3564,7 @@ int32_t ecm_interface_heirarchy_construc
++ 	 * because we add from the end first_interface grows downwards.
++ 	 */
++ 	current_interface_index = ECM_DB_IFACE_HEIRARCHY_MAX;
+++	ovs_internal_dev_cnt = 0;
++ 	while (current_interface_index > 0) {
++ 		struct ecm_db_iface_instance *ii;
++ 		struct net_device *next_dev;
++@@ -3684,6 +3688,23 @@ int32_t ecm_interface_heirarchy_construc
++ 					break;
++ 				}
++ 
+++		
+++				/* OVS internal inteface? Now we can only support upto two level ovs interface hierarchy */
+++				if (!ovs_internal_dev_cnt && ovs_is_internal_dev(dest_dev)) {
+++					struct net_device *outer_dev = NULL;
+++					uint8_t mac_addr[ETH_ALEN];
+++
+++					ovs_internal_dev_cnt = 1;
+++					memset(mac_addr, 0, ETH_ALEN);
+++					if (ecm_interface_multicast_get_next_node_mac_address(next_dest_addr, dest_dev, ip_version, mac_addr)) {
+++						outer_dev = ovs_port_dev_get(dest_dev, mac_addr, ip_version, NULL);
+++						if (outer_dev) {
+++			   				next_dev = outer_dev;
+++							dev_hold(next_dev);
+++						}
+++					}
+++				}
+++
++ #ifdef ECM_INTERFACE_BOND_ENABLE
++ 				/*
++ 				 * LAG?
+diff --git a/qsdk/qca/feeds/packages/net/openvswitch/patches/093-ovs-ecm-support.patch b/qsdk/qca/feeds/packages/net/openvswitch/patches/093-ovs-ecm-support.patch
+new file mode 100644
+index 000000000..79869f892
+--- /dev/null
++++ b/qsdk/qca/feeds/packages/net/openvswitch/patches/093-ovs-ecm-support.patch
+@@ -0,0 +1,146 @@
++--- a/datapath/datapath.c
+++++ b/datapath/datapath.c
++@@ -304,6 +304,133 @@ out:
++ 	u64_stats_update_end(&stats->syncp);
++ }
++ 
+++static struct net_device *ovs_flow_get_single_dest(struct sw_flow *flow, struct datapath *dp)
+++{
+++	struct sw_flow_actions *sf_acts;
+++	const struct nlattr *a;
+++	struct vport *vport = NULL;
+++	int rem;
+++	int port_no = -1;
+++
+++	sf_acts = rcu_dereference(flow->sf_acts);
+++
+++	for (a = sf_acts->actions, rem = sf_acts->actions_len; rem > 0;
+++	     a = nla_next(a, &rem)) {
+++		if(nla_type(a) == OVS_ACTION_ATTR_OUTPUT) {
+++			if(port_no == -1)
+++				port_no = nla_get_u32(a);
+++			else { //flow are not learned, and there are multiple dest
+++				port_no = -1;
+++				break;
+++			}
+++		}
+++	}
+++
+++	if(port_no != -1) {
+++		vport = ovs_lookup_vport(dp, port_no);
+++
+++		if (vport)
+++			return vport->dev;
+++	}
+++
+++	return NULL;
+++}
+++
+++static struct net_device *ovs_flow_find_src_dev(struct datapath *dp, char *src_mac, struct net_device *dst_dev)
+++{
+++	struct table_instance *ti;
+++	struct sw_flow_key *key;
+++	struct sw_flow *flow;
+++	struct vport *in_vport = NULL;
+++	struct vport *act_vport = NULL;
+++	struct net_device *dev = NULL;
+++	struct sw_flow_actions *sf_acts;
+++	const struct nlattr *a;
+++	int rem;
+++	int i;
+++	int ver;
+++	int in_port;
+++	int act_port;
+++
+++	ti = rcu_dereference(dp->table.ti);
+++
+++	ver = ti->node_ver;
+++	for (i = 0; i < ti->n_buckets; i++) {
+++		struct hlist_head *head;
+++
+++		head = flex_array_get(ti->buckets, i);
+++
+++		hlist_for_each_entry(flow, head, flow_table.node[ver]) {
+++			key = &flow->key;
+++
+++			if (!memcmp(key->eth.src, src_mac, ETH_ALEN) && !memcmp(key->eth.dst, dst_dev->dev_addr, ETH_ALEN)) {
+++				sf_acts = rcu_dereference(flow->sf_acts);
+++
+++				for (a = sf_acts->actions, rem = sf_acts->actions_len; rem > 0;
+++					 a = nla_next(a, &rem)) {
+++					if(nla_type(a) == OVS_ACTION_ATTR_OUTPUT) {
+++						act_port = nla_get_u32(a);
+++						act_vport = ovs_lookup_vport(dp, act_port);
+++						if (act_vport->dev == dst_dev) {
+++							in_port = key->phy.in_port;
+++							in_vport = ovs_lookup_vport(dp, in_port);
+++							dev = in_vport->dev;
+++							goto done;
+++						}
+++					}
+++				}
+++			}
+++		}
+++	}
+++
+++done:
+++	return dev;
+++}
+++
+++struct net_device *ovs_port_dev_get(struct net_device *src_dev, char *dst_mac, int ip_version, struct sk_buff *skb)
+++{
+++	struct net_device *dest_dev = NULL;
+++	struct datapath *dp;
+++	struct vport *src_vport = NULL;
+++	struct sw_flow *flow = NULL;
+++	struct sw_flow_key key;
+++
+++	src_vport = ovs_internal_dev_get_vport(src_dev);
+++	if (!src_vport)
+++		return NULL;
+++
+++	dp = src_vport->dp;
+++	if (!dp)
+++		return NULL;
+++
+++	memset(&key, 0, sizeof(struct sw_flow_key));
+++	key.phy.in_port = src_vport->port_no;
+++	key.eth.type = ip_version == 4 ? htons(ETH_P_IP) : htons(ETH_P_IPV6);
+++	memcpy(key.eth.src, src_dev->dev_addr, ETH_ALEN);
+++	memcpy(key.eth.dst, dst_mac, ETH_ALEN);
+++
+++	flow = ovs_flow_tbl_lookup(&dp->table, &key);
+++
+++	if (flow)
+++		dest_dev = ovs_flow_get_single_dest(flow, dp);
+++
+++	if (!dest_dev) {
+++		key.eth.type = htons(ETH_P_ARP);
+++		flow = ovs_flow_tbl_lookup(&dp->table, &key);
+++		if (flow)
+++			dest_dev = ovs_flow_get_single_dest(flow, dp);
+++	}
+++
+++	if (!dest_dev)
+++		dest_dev = ovs_flow_find_src_dev(dp, dst_mac, src_dev);
+++
+++	if (dest_dev && skb)
+++		ovs_flow_stats_update(flow, 0, skb);
+++
+++	return dest_dev;
+++}
+++EXPORT_SYMBOL(ovs_port_dev_get);
+++
++ int ovs_dp_upcall(struct datapath *dp, struct sk_buff *skb,
++ 		  const struct sw_flow_key *key,
++ 		  const struct dp_upcall_info *upcall_info,
++--- a/datapath/vport-internal_dev.c
+++++ b/datapath/vport-internal_dev.c
++@@ -299,6 +299,7 @@ int ovs_is_internal_dev(const struct net
++ {
++ 	return netdev->netdev_ops == &internal_dev_netdev_ops;
++ }
+++EXPORT_SYMBOL(ovs_is_internal_dev);
++ 
++ struct vport *ovs_internal_dev_get_vport(struct net_device *netdev)
++ {


### PR DESCRIPTION
The interfaces of ovs going through post routing would be LOCAL port rather than
actual ingress/egress ports. We retrieve them by using ovs flow and use them to
establish the correct hierarchy from which ECM module learn the connection.